### PR TITLE
Add "readonly" attribute to bootstrapdatepicker HTML input element

### DIFF
--- a/src/bootstrapdatepicker.js
+++ b/src/bootstrapdatepicker.js
@@ -18,7 +18,7 @@ function init(Survey, $) {
             return question.getType() === "bootstrapdatepicker";
         },
         htmlTemplate:
-            "<input class='form-control widget-datepicker' type='text' style='width: 100%;'>",
+            "<input class='form-control widget-datepicker' type='text' style='width: 100%;' readonly>",
         activatedByChanged: function (activatedBy) {
             Survey.JsonObject.metaData.addClass(
                 "bootstrapdatepicker",


### PR DESCRIPTION
This ensures that the value in the input field can only be changed via the datepicker. Without this attribute, users may click into the input field and add arbitrary text by typing on their keyboard. This should almost never be what one (as a developer) wants when using a datepicker widget.

Note that this is completely orthogonal to the datepicker's `enableOnReadonly` and to SurveyJS's `isReadOnly` attributes.