### PR TITLE
using `allowAddNewTag` works incorrect. If we have only one answer and it is "custom" then it removes from the `survey.data`

### DIFF
--- a/src/select2-tagbox.js
+++ b/src/select2-tagbox.js
@@ -73,6 +73,9 @@ function init(Survey, $) {
       if (!settings) settings = {};
       settings.placeholder = question.placeholder;
       settings.tags = question.allowAddNewTag;
+      if (question.allowAddNewTag) {
+        question.keepIncorrectValues = true;
+      }
       settings.disabled = question.isReadOnly;
       settings.theme = "classic";
       if (!!question.maxSelectedChoices) {


### PR DESCRIPTION
see https://github.com/surveyjs/custom-widgets/issues/281