### PR TITLE
Add numericGroupSeparator as a serializable property in inputmask plugin

### DIFF
--- a/src/inputmask.js
+++ b/src/inputmask.js
@@ -94,6 +94,12 @@ function init(Survey) {
           visible: false,
         },
         {
+          name: "numericGroupSeparator",
+          category: "general",
+          default: ",",
+          visible: false,
+        },
+        {
           name: "options",
           category: "general",
           visible: false,
@@ -159,7 +165,7 @@ function init(Survey) {
         surveyElement.inputMask === "currency" ||
         surveyElement.inputMask === "decimal"
       ) {
-        options.groupSeparator = rootWidget.numericGroupSeparator;
+        options.groupSeparator = surveyElement.numericGroupSeparator || rootWidget.numericGroupSeparator;
         options.radixPoint = rootWidget.numericRadixPoint;
         options.autoGroup = rootWidget.numericAutoGroup;
         options.placeholder = rootWidget.numericPlaceholder;        


### PR DESCRIPTION
Currently, there is no way to customize the `numericGroupSeparator` options in the inputmask plugin. Therefore when using a `decimal` or `currency` mask, we are forced to use `,` as separator (e.g. `123,456.00`).

The changes in this PR allows users to override the separator in their survey config JSON, by adding `numericGroupSeparator` as a serializable property like it is already the case for other properties such as `suffix` or `numericDigits`