### PR TITLE
fix(jquery-datepicker): clear value when datepicker is cleared

### DIFF
--- a/src/jquery-ui-datepicker.js
+++ b/src/jquery-ui-datepicker.js
@@ -116,6 +116,10 @@ function init(Survey, $) {
       };
       function setDateIntoQuestion() {
         var val = $el.datepicker('getDate');
+        if (!val || typeof val.setHours !== 'function') {
+          question.value = '';
+          return;
+        }
         var d = new Date();
         val.setHours(d.getHours());
         val.setMinutes(d.getMinutes());


### PR DESCRIPTION
Fix bug that prevents user from clearing date value.

**Steps to reproduce:**
1. Go to https://surveyjs.io/form-library/examples/custom-widget-datepicker/jquery
2. Set date using datepicker
3. Clear date by deleting input text (Delete key)
4. Click **Complete** button to submit form
5. Click **JSON** tab to view submitted data

**Expected behaviour:**
- Date value is empty

**Actual behaviour:**
- Date value did not clear and is set to:
  ```
  { "date": "2024-04-09T01:29:51.000Z" }
  ```
- JS console error:
  ```
  jquery-ui-datepicker.js:120 Uncaught TypeError: Cannot read properties of null (reading 'setHours')
      at r (jquery-ui-datepicker.js:120:13)
      at o.onSelect.o.onSelect (jquery-ui-datepicker.js:101:11)
      at st._selectDate (jquery-ui.min.js:6:101656)
      at st._clearDate (jquery-ui.min.js:6:101467)
      at HTMLInputElement.<anonymous> (jquery-ui-datepicker.js:131:24)
      at HTMLInputElement.dispatch (jquery.min.js:2:43336)
      at y.handle (jquery.min.js:2:41320)
  ```

**Screenshots:**
![Screenshot 2024-04-08 at 11 26 58 AM](https://github.com/surveyjs/custom-widgets/assets/832191/6e519b4c-4e01-4a92-b347-3df4c1c6e540)
![Screenshot 2024-04-08 at 11 27 04 AM](https://github.com/surveyjs/custom-widgets/assets/832191/c5ff652c-44b9-41da-8642-840ba0f82506)
![Screenshot 2024-04-08 at 11 29 11 AM](https://github.com/surveyjs/custom-widgets/assets/832191/716215a0-376f-4896-9523-ab53d4de97f2)

